### PR TITLE
Add volume for persistent application logs

### DIFF
--- a/docker-compose.deploy.test.yml
+++ b/docker-compose.deploy.test.yml
@@ -5,3 +5,8 @@ services:
       - .env
     ports:
       - "$APP_PORT:$APP_PORT"
+    volumes:
+      - app-logs:/app/logs
+
+volumes:
+  app-logs:


### PR DESCRIPTION
Modifies `docker-compose.deploy.test.yml` to include a named volume (`app-logs`). This volume is mounted to `/app/logs` in the `app` service container.

This change ensures that application logs generated within the Docker container are persisted even if the container is stopped or removed, facilitating easier debugging and log management on test deployments.