### PR TITLE
Enable async DB writes

### DIFF
--- a/cli/receiver/main.go
+++ b/cli/receiver/main.go
@@ -77,6 +77,9 @@ func main() {
 		defer store.Close()
 	}
 
-	srv := server.NewCustom(cfg.GetListenAddress(), cfg.GetEmptyConnTTL(), storages)
+	asyncRepo := storage.NewAsyncRepository(storages, 1024, 0)
+	defer asyncRepo.Close()
+
+	srv := server.NewCustom(cfg.GetListenAddress(), cfg.GetEmptyConnTTL(), asyncRepo)
 	srv.Run()
 }

--- a/cli/receiver/server/custom_server.go
+++ b/cli/receiver/server/custom_server.go
@@ -16,7 +16,7 @@ type CustomServer struct {
 	Server
 }
 
-func NewCustom(addr string, ttl time.Duration, store *storage.Repository) *CustomServer {
+func NewCustom(addr string, ttl time.Duration, store storage.Saver) *CustomServer {
 	return &CustomServer{Server: New(addr, ttl, store)}
 }
 

--- a/cli/receiver/server/server.go
+++ b/cli/receiver/server/server.go
@@ -21,7 +21,7 @@ const (
 type Server struct {
 	addr  string
 	ttl   time.Duration
-	store *storage.Repository
+	store storage.Saver
 	l     net.Listener
 }
 
@@ -318,7 +318,7 @@ func (s *Server) handleConn(conn net.Conn) {
 	}
 }
 
-func New(srvAddress string, ttl time.Duration, s *storage.Repository) Server {
+func New(srvAddress string, ttl time.Duration, s storage.Saver) Server {
 	return Server{
 		addr:  srvAddress,
 		ttl:   ttl,

--- a/cli/receiver/storage/async_repository.go
+++ b/cli/receiver/storage/async_repository.go
@@ -1,0 +1,72 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"sync"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// AsyncRepository wraps Repository and performs saving in background workers.
+type AsyncRepository struct {
+	repo   *Repository
+	ch     chan interface{ ToBytes() ([]byte, error) }
+	wg     sync.WaitGroup
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+// NewAsyncRepository creates asynchronous repository with given buffer and workers count.
+func NewAsyncRepository(repo *Repository, buffer, workers int) *AsyncRepository {
+	if workers <= 0 {
+		workers = runtime.NumCPU()
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	ar := &AsyncRepository{
+		repo:   repo,
+		ch:     make(chan interface{ ToBytes() ([]byte, error) }, buffer),
+		ctx:    ctx,
+		cancel: cancel,
+	}
+	for i := 0; i < workers; i++ {
+		ar.wg.Add(1)
+		go ar.worker()
+	}
+	return ar
+}
+
+func (a *AsyncRepository) worker() {
+	defer a.wg.Done()
+	for {
+		select {
+		case msg, ok := <-a.ch:
+			if !ok {
+				return
+			}
+			if err := a.repo.Save(msg); err != nil {
+				log.WithField("err", err).Error("Ошибка сохранения телеметрии")
+			}
+		case <-a.ctx.Done():
+			return
+		}
+	}
+}
+
+// Save places message into queue for asynchronous saving.
+func (a *AsyncRepository) Save(m interface{ ToBytes() ([]byte, error) }) error {
+	select {
+	case a.ch <- m:
+		return nil
+	case <-a.ctx.Done():
+		return fmt.Errorf("async repository closed")
+	}
+}
+
+// Close stops workers and waits for completion.
+func (a *AsyncRepository) Close() {
+	a.cancel()
+	close(a.ch)
+	a.wg.Wait()
+}

--- a/configs/config.test.yaml
+++ b/configs/config.test.yaml
@@ -1,0 +1,16 @@
+host: "127.0.0.1"
+port: "7001"
+conn_ttl: 5
+log_level: "DEBUG"
+log_file_path: "logs/app_test.log"
+log_max_age_days: 1
+
+storage:
+  postgresql:
+    host: "localhost"
+    port: "5432"
+    user: "postgres"
+    password: "postgres"
+    database: "egts"
+    table: "points"
+    sslmode: disable


### PR DESCRIPTION
## Summary
- implement `AsyncRepository` to store packets in background workers
- use async repository when starting receiver
- adjust server constructors to work with any storage saver
- add minimal test config for receiver

## Testing
- `TEST_CONFIG=$(pwd)/configs/config.test.yaml go test ./...` *(fails: dial tcp [::1]:5432: connect: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6840aab502048330bb3554249ba70633