### PR TITLE
feat: Implement configurable database save window

### DIFF
--- a/cli/receiver/config/config.go
+++ b/cli/receiver/config/config.go
@@ -21,6 +21,8 @@ type Settings struct {
 	LogFilePath string                    `yaml:"log_file_path"`
 	LogMaxAgeDays int                     `yaml:"log_max_age_days"`
 	Store    map[string]map[string]string `yaml:"storage"`
+	DBSaveMonthStart int `yaml:"db_save_month_start"`
+	DBSaveMonthEnd int `yaml:"db_save_month_end"`
 }
 
 func (s *Settings) GetEmptyConnTTL() time.Duration {
@@ -55,5 +57,36 @@ func New(confPath string) (Settings, error) {
 		return c, err
 	}
 	err = yaml.Unmarshal(data, &c)
+	if err != nil {
+		return c, err
+	}
+
+	if c.DBSaveMonthStart == 0 {
+		c.DBSaveMonthStart = 5 // Default to May
+	}
+	if c.DBSaveMonthEnd == 0 {
+		c.DBSaveMonthEnd = 9 // Default to September
+	}
+
+	if c.DBSaveMonthStart < 1 || c.DBSaveMonthStart > 12 || c.DBSaveMonthEnd < 1 || c.DBSaveMonthEnd > 12 {
+		log.Errorf("Invalid DBSaveMonthStart (%d) or DBSaveMonthEnd (%d). Values must be between 1 and 12. Defaulting to May (5) and September (9).", c.DBSaveMonthStart, c.DBSaveMonthEnd)
+		c.DBSaveMonthStart = 5
+		c.DBSaveMonthEnd = 9
+	}
+
+	if c.DBSaveMonthStart > c.DBSaveMonthEnd {
+		log.Errorf("DBSaveMonthStart (%d) cannot be after DBSaveMonthEnd (%d). Defaulting to May (5) and September (9).", c.DBSaveMonthStart, c.DBSaveMonthEnd)
+		c.DBSaveMonthStart = 5
+		c.DBSaveMonthEnd = 9
+	}
+
 	return c, err
+}
+
+func (s *Settings) GetDBSaveMonthStart() int {
+	return s.DBSaveMonthStart
+}
+
+func (s *Settings) GetDBSaveMonthEnd() int {
+	return s.DBSaveMonthEnd
 }

--- a/cli/receiver/config/config_test.go
+++ b/cli/receiver/config/config_test.go
@@ -5,9 +5,14 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+
+	log "github.com/sirupsen/logrus"
 )
 
 func TestConfigLoad(t *testing.T) {
+	// To prevent log output during tests
+	log.SetOutput(ioutil.Discard)
+
 	cfg := `host: "127.0.0.1"
 port: "5020"
 conn_ttl: 10
@@ -47,6 +52,7 @@ storage:
 			Port:     "5020",
 			ConnTTl:  10,
 			LogLevel: "DEBUG",
+			// LogFilePath and LogMaxAgeDays remain as zero values if not in YAML
 			Store: map[string]map[string]string{
 				"postgresql": {
 					"host":     "localhost",
@@ -65,8 +71,126 @@ storage:
 					"user":     "guest",
 				},
 			},
+			DBSaveMonthStart: 5, // Default value
+			DBSaveMonthEnd:   9, // Default value
 		},
 			conf,
 		)
+	}
+}
+
+func TestDBSaveMonthRange(t *testing.T) {
+	// To prevent log output during tests
+	log.SetOutput(ioutil.Discard)
+
+	tests := []struct {
+		name                 string
+		yamlContent          string
+		expectedStartMonth   int
+		expectedEndMonth     int
+		expectError          bool
+		deleteFileAfterwards bool
+	}{
+		{
+			name: "Fields provided in YAML",
+			yamlContent: `
+db_save_month_start: 3
+db_save_month_end: 10
+`,
+			expectedStartMonth: 3,
+			expectedEndMonth:   10,
+			deleteFileAfterwards: true,
+		},
+		{
+			name: "Fields not provided (defaults)",
+			yamlContent: `
+# empty config
+`,
+			expectedStartMonth: 5, // Default May
+			expectedEndMonth:   9, // Default September
+			deleteFileAfterwards: true,
+		},
+		{
+			name: "Invalid month values (0, 13)",
+			yamlContent: `
+db_save_month_start: 0
+db_save_month_end: 13
+`,
+			expectedStartMonth: 5, // Default May (due to validation)
+			expectedEndMonth:   9, // Default September (due to validation)
+			deleteFileAfterwards: true,
+		},
+		{
+			name: "Start month after end month (invalid simple range)",
+			yamlContent: `
+db_save_month_start: 11
+db_save_month_end: 2
+`,
+			expectedStartMonth: 5, // Default May (due to validation)
+			expectedEndMonth:   9, // Default September (due to validation)
+			deleteFileAfterwards: true,
+		},
+		{
+			name:                 "Non-existent config file",
+			yamlContent:          "", // No content, file won't be created for this specific sub-test
+			expectedStartMonth:   0,  // Expect 0 as defaults are not applied if file read fails
+			expectedEndMonth:     0,  // Expect 0 as defaults are not applied if file read fails
+			expectError:          true, // Expect error when loading non-existent file
+			deleteFileAfterwards: false, // No file to delete
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var confPath string
+			var err error
+
+			if tt.yamlContent != "" || tt.name == "Fields not provided (defaults)" { // Second condition to create empty file for default test
+				file, err := ioutil.TempFile("", "test_config_*.yaml")
+				if !assert.NoError(t, err, "Failed to create temp file for test: %s", tt.name) {
+					return
+				}
+				confPath = file.Name()
+
+				if tt.yamlContent != "" {
+					_, err = file.WriteString(tt.yamlContent)
+					if !assert.NoError(t, err, "Failed to write to temp file for test: %s", tt.name) {
+						file.Close()
+						if tt.deleteFileAfterwards { os.Remove(confPath) }
+						return
+					}
+				}
+				file.Close() // Close the file before New() tries to read it
+			} else if tt.name == "Non-existent config file" {
+				confPath = "/tmp/non_existent_config_for_test.yaml" // A path that should not exist
+			}
+
+
+			cfg, err := New(confPath)
+
+			if tt.deleteFileAfterwards && confPath != "" {
+				errRemove := os.Remove(confPath)
+				assert.NoError(t, errRemove, "Failed to remove temp file: %s for test: %s", confPath, tt.name)
+			}
+
+			if tt.expectError {
+				assert.Error(t, err, "Expected an error for test: %s", tt.name)
+				// When an error is expected (like file not found),
+				// the cfg object might not be fully initialized or might be zeroed.
+				// When an error is expected (like file not found),
+				// the cfg object is the zero-value one returned before default logic is applied.
+				assert.Equal(t, tt.expectedStartMonth, cfg.DBSaveMonthStart, "Start month should be 0 for error test: %s", tt.name)
+				assert.Equal(t, tt.expectedEndMonth, cfg.DBSaveMonthEnd, "End month should be 0 for error test: %s", tt.name)
+				// Also check getters which would return these 0 values
+				assert.Equal(t, tt.expectedStartMonth, cfg.GetDBSaveMonthStart(), "Getter start month mismatch for error test: %s", tt.name)
+				assert.Equal(t, tt.expectedEndMonth, cfg.GetDBSaveMonthEnd(), "Getter end month mismatch for error test: %s", tt.name)
+			} else {
+				if !assert.NoError(t, err, "Unexpected error for test: %s", tt.name) {
+					return
+				}
+				assert.Equal(t, tt.expectedStartMonth, cfg.GetDBSaveMonthStart(), "Start month mismatch for test: %s", tt.name)
+				assert.Equal(t, tt.expectedEndMonth, cfg.GetDBSaveMonthEnd(), "End month mismatch for test: %s", tt.name)
+			}
+		})
 	}
 }

--- a/cli/receiver/main.go
+++ b/cli/receiver/main.go
@@ -64,7 +64,7 @@ func main() {
 		log.AddHook(hook)
 	}
 
-	storages := storage.NewRepository()
+	storages := storage.NewRepository(cfg.GetDBSaveMonthStart(), cfg.GetDBSaveMonthEnd())
 	if err := storages.LoadStorages(cfg.Store); err != nil {
 		log.Errorf("Ошибка загрузки хранилища: %v", err)
 

--- a/cli/receiver/storage/store_test.go
+++ b/cli/receiver/storage/store_test.go
@@ -1,0 +1,150 @@
+package storage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	log "github.com/sirupsen/logrus"
+	"io/ioutil"
+)
+
+// mockSaver implements the Saver interface for testing.
+type mockSaver struct {
+	saveCalled bool
+	// saveCallCount int // Alternative: count calls
+}
+
+// Save marks saveCalled as true.
+func (ms *mockSaver) Save(data interface{ ToBytes() ([]byte, error) }) error {
+	ms.saveCalled = true
+	// ms.saveCallCount++
+	return nil
+}
+
+// testData is a simple struct for testing the Save method.
+type testData struct{}
+
+// ToBytes returns a dummy byte slice and no error.
+func (td testData) ToBytes() ([]byte, error) {
+	return []byte("test"), nil
+}
+
+func TestRepository_Save_DateLogic(t *testing.T) {
+	// Discard logs during tests to keep output clean
+	log.SetOutput(ioutil.Discard)
+
+	dummyData := testData{}
+
+	tests := []struct {
+		name              string
+		repoStartMonth    int
+		repoEndMonth      int
+		mockedCurrentTime time.Time
+		expectSave        bool
+	}{
+		// Scenario 1: Current month (July) WITHIN range (May-September)
+		{
+			name:              "July within May-September",
+			repoStartMonth:    5,  // May
+			repoEndMonth:      9,  // September
+			mockedCurrentTime: time.Date(2023, time.July, 15, 0, 0, 0, 0, time.UTC),
+			expectSave:        true,
+		},
+		// Scenario 2: Current month (October) OUTSIDE range (May-September)
+		{
+			name:              "October outside May-September",
+			repoStartMonth:    5,  // May
+			repoEndMonth:      9,  // September
+			mockedCurrentTime: time.Date(2023, time.October, 15, 0, 0, 0, 0, time.UTC),
+			expectSave:        false,
+		},
+		// Scenario 3: Current month (May) at START of range (May-September)
+		{
+			name:              "May at start of May-September",
+			repoStartMonth:    5,  // May
+			repoEndMonth:      9,  // September
+			mockedCurrentTime: time.Date(2023, time.May, 1, 0, 0, 0, 0, time.UTC),
+			expectSave:        true,
+		},
+		// Scenario 4: Current month (September) at END of range (May-September)
+		{
+			name:              "September at end of May-September",
+			repoStartMonth:    5,  // May
+			repoEndMonth:      9,  // September
+			mockedCurrentTime: time.Date(2023, time.September, 30, 0, 0, 0, 0, time.UTC),
+			expectSave:        true,
+		},
+		// Scenario 5: Current month (January) WITHIN wrap-around range (November-February)
+		{
+			name:              "January within November-February (wrap-around)",
+			repoStartMonth:    11, // November
+			repoEndMonth:      2,  // February
+			mockedCurrentTime: time.Date(2023, time.January, 15, 0, 0, 0, 0, time.UTC),
+			expectSave:        true,
+		},
+		// Scenario 6: Current month (November) at START of wrap-around range (November-February)
+		{
+			name:              "November at start of November-February (wrap-around)",
+			repoStartMonth:    11, // November
+			repoEndMonth:      2,  // February
+			mockedCurrentTime: time.Date(2023, time.November, 1, 0, 0, 0, 0, time.UTC),
+			expectSave:        true,
+		},
+		// Scenario 7: Current month (February) at END of wrap-around range (November-February)
+		{
+			name:              "February at end of November-February (wrap-around)",
+			repoStartMonth:    11, // November
+			repoEndMonth:      2,  // February
+			mockedCurrentTime: time.Date(2023, time.February, 28, 0, 0, 0, 0, time.UTC),
+			expectSave:        true,
+		},
+		// Scenario 8: Current month (March) OUTSIDE wrap-around range (November-February)
+		{
+			name:              "March outside November-February (wrap-around)",
+			repoStartMonth:    11, // November
+			repoEndMonth:      2,  // February
+			mockedCurrentTime: time.Date(2023, time.March, 15, 0, 0, 0, 0, time.UTC),
+			expectSave:        false,
+		},
+		// Additional edge case: Current month (April) OUTSIDE range (May-September) - before start
+		{
+			name:              "April outside May-September (before start)",
+			repoStartMonth:    5,  // May
+			repoEndMonth:      9,  // September
+			mockedCurrentTime: time.Date(2023, time.April, 15, 0, 0, 0, 0, time.UTC),
+			expectSave:        false,
+		},
+		// Additional edge case: Current month (October) OUTSIDE wrap-around range (November-February) - between end and start
+		{
+			name:              "October outside November-February (between end and start)",
+			repoStartMonth:    11, // November
+			repoEndMonth:      2,  // February
+			mockedCurrentTime: time.Date(2023, time.October, 15, 0, 0, 0, 0, time.UTC),
+			expectSave:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup mock saver
+			saver := &mockSaver{}
+
+			// Setup repository with the specified month range
+			repo := NewRepository(tt.repoStartMonth, tt.repoEndMonth)
+			repo.AddStore(saver)
+
+			// Mock time.Now()
+			originalNow := now
+			now = func() time.Time { return tt.mockedCurrentTime }
+			defer func() { now = originalNow }() // Restore original time.Now
+
+			// Call Save
+			err := repo.Save(dummyData)
+			assert.NoError(t, err, "repo.Save should not return an error in these test cases")
+
+			// Assert
+			assert.Equal(t, tt.expectSave, saver.saveCalled, "Save called status mismatch")
+		})
+	}
+}

--- a/configs/config.docker.test.yaml
+++ b/configs/config.docker.test.yaml
@@ -4,6 +4,8 @@ conn_ttl: 5
 log_level: "DEBUG"
 log_file_path: "logs/app.log"
 log_max_age_days: 366
+# db_save_month_start: 5  # Month to start saving to DB (1=Jan, 12=Dec), inclusive. Default: 5 (May)
+# db_save_month_end: 9    # Month to end saving to DB (1=Jan, 12=Dec), inclusive. Default: 9 (September)
 
 storage:
   postgresql:

--- a/configs/config.docker.yaml
+++ b/configs/config.docker.yaml
@@ -4,6 +4,8 @@ conn_ttl: 5
 log_level: "DEBUG"
 log_file_path: "logs/app.log"
 log_max_age_days: 366
+# db_save_month_start: 5  # Month to start saving to DB (1=Jan, 12=Dec), inclusive. Default: 5 (May)
+# db_save_month_end: 9    # Month to end saving to DB (1=Jan, 12=Dec), inclusive. Default: 9 (September)
 
 storage:
   postgresql:

--- a/configs/config.test.yaml
+++ b/configs/config.test.yaml
@@ -4,6 +4,8 @@ conn_ttl: 5
 log_level: "DEBUG"
 log_file_path: "logs/app_test.log"
 log_max_age_days: 1
+# db_save_month_start: 5  # Month to start saving to DB (1=Jan, 12=Dec), inclusive. Default: 5 (May)
+# db_save_month_end: 9    # Month to end saving to DB (1=Jan, 12=Dec), inclusive. Default: 9 (September)
 
 storage:
   postgresql:

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -4,6 +4,8 @@ conn_ttl: 5
 log_level: "DEBUG"
 log_file_path: "logs/app.log"
 log_max_age_days: 366
+# db_save_month_start: 5  # Month to start saving to DB (1=Jan, 12=Dec), inclusive. Default: 5 (May)
+# db_save_month_end: 9    # Month to end saving to DB (1=Jan, 12=Dec), inclusive. Default: 9 (September)
 
 storage:
   postgresql:


### PR DESCRIPTION
This change introduces a feature to restrict database writes to a specific range of months, configurable via your application's YAML configuration files.

Key changes:
- Added `db_save_month_start` and `db_save_month_end` integer fields to the configuration (`config.go`). These fields define the inclusive range of months during which data should be saved. Default values are May (5) and September (9) if not specified. Validation ensures months are between 1 and 12.
- Modified the `storage.Repository` to store these configured start and end months.
- The `Repository.Save` method now checks the current month against this configured range. If the current month is outside the range, a log message is issued, and the save operation is skipped. This logic correctly handles ranges that span across the year-end (e.g., Nov-Feb).
- Updated `main.go` to pass the configured month values from the config to the `Repository`.
- Added comprehensive unit tests for both the configuration parsing (including defaults and validation) and the date-based save logic in `store.go`. The latter uses time mocking to simulate different months and test various scenarios.
- Updated example configuration files (`*.yaml`) to include the new parameters, commented out with descriptions and default values.